### PR TITLE
Fix timestamp parsing bug

### DIFF
--- a/src/pypvs/models/ess.py
+++ b/src/pypvs/models/ess.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timezone
 
 from dataclasses import dataclass
 from typing import Any
@@ -40,7 +40,7 @@ class PVSESS:
         # Convert date from format "2024-09-30T16:15:00Z" to UTC seconds
         date_str = data.get("msmtEps", "1970-01-01T00:00:00Z")
         try:
-            dt = datetime.strptime(date_str, "%Y-%m-%dT%H:%M:%SZ")
+            dt = datetime.strptime(date_str, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc)
             last_report_date = int(dt.timestamp())
         except Exception:
             last_report_date = 0

--- a/src/pypvs/models/inverter.py
+++ b/src/pypvs/models/inverter.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timezone
 
 from dataclasses import dataclass
 from typing import Any
@@ -28,7 +28,7 @@ class PVSInverter:
 
         # Convert date from format "2024-09-30T16:15:00Z" to UTC seconds
         date_str = data["msmtEps"]
-        dt = datetime.strptime(date_str, "%Y-%m-%dT%H:%M:%SZ")
+        dt = datetime.strptime(date_str, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc)
         last_report_date = int(dt.timestamp())
 
         return cls(

--- a/src/pypvs/models/meter.py
+++ b/src/pypvs/models/meter.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timezone
 
 from dataclasses import dataclass
 from typing import Any
@@ -42,7 +42,7 @@ class PVSMeter:
         # Convert date from format "2024-09-30T16:15:00Z" to UTC seconds
         date_str = data.get("msmtEps", "1970-01-01T00:00:00Z")
         try:
-            dt = datetime.strptime(date_str, "%Y-%m-%dT%H:%M:%SZ")
+            dt = datetime.strptime(date_str, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc)
             last_report_date = int(dt.timestamp())
         except Exception:
             last_report_date = 0

--- a/src/pypvs/models/transfer_switch.py
+++ b/src/pypvs/models/transfer_switch.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timezone
 
 from dataclasses import dataclass
 from typing import Any
@@ -29,7 +29,7 @@ class PVSTransferSwitch:
         """Initialize from /sys/devices/transfer_switch/*/* varserver variables packed in JSON."""
         date_str = data.get("msmtEps", "1970-01-01T00:00:00Z")
         try:
-            dt = datetime.strptime(date_str, "%Y-%m-%dT%H:%M:%SZ")
+            dt = datetime.strptime(date_str, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc)
             last_report_date = int(dt.timestamp())
         except Exception:
             last_report_date = 0


### PR DESCRIPTION
Last Reported timestamp is showing a time in the future. Refer to the bug reported here: 

https://github.com/SunStrong-Management/pvs-hass/issues/9

This is due to a bug in the parsing of the UTC timestamp string from the PVS. `datetime.strptime` creates a naive datetime object. Calling .timestamp() on a naive datetime assumes the datetime is in your local timezone and converts it to UTC (so in my case it was adding +4 hours to the timestamp). This change adds UTC to the datetime object making it timezone-aware, ensuring the .timestamp() function does not perform a conversion.