### PR TITLE
Add support for real-time live data from PVS via WebSocket

### DIFF
--- a/examples/livedata_websocket_async.py
+++ b/examples/livedata_websocket_async.py
@@ -1,0 +1,78 @@
+# This is an example of how to use the PVSWebSocket class to receive
+# real-time live data from a SunStrong Management PVS6 gateway.
+#
+# The WebSocket provides faster updates than polling the HTTP API,
+# typically pushing data every few seconds.
+
+import asyncio
+import logging
+import os
+
+from pypvs.pvs_websocket import PVSWebSocket
+
+logging.basicConfig(level=logging.INFO)
+_LOGGER = logging.getLogger(__name__)
+
+
+def on_live_data_update(changed_vars: set[str]) -> None:
+    """Callback when live data is updated."""
+    _LOGGER.info(f"Data updated for: {changed_vars}")
+
+
+async def main():
+    # Get PVS host from environment variable
+    host = os.getenv("PVS_HOST")
+    if host is None:
+        print("Please set the PVS_HOST environment variable with the PVS IP.")
+        return
+
+    # Create WebSocket client
+    ws = PVSWebSocket(host=host)
+
+    # Add listener for updates
+    remove_listener = ws.add_listener(on_live_data_update)
+
+    # Connect (starts background task with auto-reconnect)
+    await ws.connect()
+    _LOGGER.info(f"WebSocket connecting to {host}...")
+
+    try:
+        # Print live data every 5 seconds
+        while True:
+            await asyncio.sleep(5)
+
+            live_data = ws.live_data
+            if live_data is None:
+                _LOGGER.info("Waiting for connection...")
+                continue
+
+            print("\n" + "=" * 50)
+            print("Live Data:")
+            print(f"  Timestamp:        {live_data.time}")
+            print(f"  PV Power:         {live_data.pv_p} kW")
+            print(f"  PV Energy:        {live_data.pv_en} kWh")
+            print(f"  Net Power:        {live_data.net_p} kW")
+            print(f"  Net Energy:       {live_data.net_en} kWh")
+            print(f"  Site Load Power:  {live_data.site_load_p} kW")
+            print(f"  Site Load Energy: {live_data.site_load_en} kWh")
+            print(f"  ESS Power:        {live_data.ess_p} kW")
+            print(f"  ESS Energy:       {live_data.ess_en} kWh")
+            print(f"  Battery SOC:      {live_data.soc}%")
+            print(f"  Backup Time:      {live_data.backup_time_remaining} min")
+            print(f"  MIDC State:       {live_data.midstate}")
+            print("=" * 50)
+
+    except asyncio.CancelledError:
+        pass
+    finally:
+        # Clean up
+        remove_listener()
+        await ws.disconnect()
+        _LOGGER.info("Disconnected")
+
+
+if __name__ == "__main__":
+    try:
+        asyncio.run(main())
+    except KeyboardInterrupt:
+        print("\nExiting...")

--- a/examples/livedata_websocket_async.py
+++ b/examples/livedata_websocket_async.py
@@ -55,11 +55,16 @@ async def main():
             print(f"  Net Energy:       {live_data.net_en} kWh")
             print(f"  Site Load Power:  {live_data.site_load_p} kW")
             print(f"  Site Load Energy: {live_data.site_load_en} kWh")
-            print(f"  ESS Power:        {live_data.ess_p} kW")
-            print(f"  ESS Energy:       {live_data.ess_en} kWh")
-            print(f"  Battery SOC:      {live_data.soc}%")
-            print(f"  Backup Time:      {live_data.backup_time_remaining} min")
-            print(f"  MIDC State:       {live_data.midstate}")
+            if live_data.ess_p is not None:
+                print(f"  ESS Power:        {live_data.ess_p} kW")
+            if live_data.ess_en is not None:
+                print(f"  ESS Energy:       {live_data.ess_en} kWh")
+            if live_data.soc is not None:
+                print(f"  Battery SOC:      {live_data.soc} %")
+            if live_data.backup_time_remaining is not None:
+                print(f"  Backup Time:      {live_data.backup_time_remaining} min")
+            if live_data.midstate is not None:
+                print(f"  MIDC State:       {live_data.midstate}")
             print("=" * 50)
 
     except asyncio.CancelledError:

--- a/examples/livedata_websocket_async.py
+++ b/examples/livedata_websocket_async.py
@@ -8,7 +8,10 @@ import asyncio
 import logging
 import os
 
-from pypvs.pvs_websocket import PVSWebSocket
+import aiohttp
+
+from pypvs.exceptions import ENDPOINT_PROBE_EXCEPTIONS
+from pypvs.pvs import PVS
 
 logging.basicConfig(level=logging.INFO)
 _LOGGER = logging.getLogger(__name__)
@@ -26,54 +29,66 @@ async def main():
         print("Please set the PVS_HOST environment variable with the PVS IP.")
         return
 
-    # Create WebSocket client
-    ws = PVSWebSocket(host=host)
+    async with aiohttp.ClientSession() as session:
+        pvs = PVS(session=session, host=host, user="ssm_owner")
+        try:
+            await pvs.discover()
+            pvs_serial = pvs.serial_number
+            pvs_password = pvs_serial[-5:]
+            await pvs.setup(auth_password=pvs_password)
+            _LOGGER.info(f"Connected to PVS with serial: {pvs_serial}")
+        except ENDPOINT_PROBE_EXCEPTIONS as e:
+            _LOGGER.error(f"Cannot communicate with the PVS: {e}")
+            return
 
-    # Add listener for updates
-    remove_listener = ws.add_listener(on_live_data_update)
+        # Create WebSocket client with automatic telemetry enable
+        ws = pvs.get_websocket()
 
-    # Connect (starts background task with auto-reconnect)
-    await ws.connect()
-    _LOGGER.info(f"WebSocket connecting to {host}...")
+        # Add listener for updates
+        remove_listener = ws.add_listener(on_live_data_update)
 
-    try:
-        # Print live data every 5 seconds
-        while True:
-            await asyncio.sleep(5)
+        # Connect (starts background task with auto-reconnect)
+        await ws.connect()
+        _LOGGER.info(f"WebSocket connecting to {host}...")
 
-            live_data = ws.live_data
-            if live_data is None:
-                _LOGGER.info("Waiting for connection...")
-                continue
+        try:
+            # Print live data every 5 seconds
+            while True:
+                await asyncio.sleep(5)
 
-            print("\n" + "=" * 50)
-            print("Live Data:")
-            print(f"  Timestamp:        {live_data.time}")
-            print(f"  PV Power:         {live_data.pv_p} kW")
-            print(f"  PV Energy:        {live_data.pv_en} kWh")
-            print(f"  Net Power:        {live_data.net_p} kW")
-            print(f"  Net Energy:       {live_data.net_en} kWh")
-            print(f"  Site Load Power:  {live_data.site_load_p} kW")
-            print(f"  Site Load Energy: {live_data.site_load_en} kWh")
-            if live_data.ess_p is not None:
-                print(f"  ESS Power:        {live_data.ess_p} kW")
-            if live_data.ess_en is not None:
-                print(f"  ESS Energy:       {live_data.ess_en} kWh")
-            if live_data.soc is not None:
-                print(f"  Battery SOC:      {live_data.soc} %")
-            if live_data.backup_time_remaining is not None:
-                print(f"  Backup Time:      {live_data.backup_time_remaining} min")
-            if live_data.midstate is not None:
-                print(f"  MIDC State:       {live_data.midstate}")
-            print("=" * 50)
+                live_data = ws.live_data
+                if live_data is None:
+                    _LOGGER.info("Waiting for connection...")
+                    continue
 
-    except asyncio.CancelledError:
-        pass
-    finally:
-        # Clean up
-        remove_listener()
-        await ws.disconnect()
-        _LOGGER.info("Disconnected")
+                print("\n" + "=" * 50)
+                print("Live Data:")
+                print(f"  Timestamp:        {live_data.time}")
+                print(f"  PV Power:         {live_data.pv_p} kW")
+                print(f"  PV Energy:        {live_data.pv_en} kWh")
+                print(f"  Net Power:        {live_data.net_p} kW")
+                print(f"  Net Energy:       {live_data.net_en} kWh")
+                print(f"  Site Load Power:  {live_data.site_load_p} kW")
+                print(f"  Site Load Energy: {live_data.site_load_en} kWh")
+                if live_data.ess_p is not None:
+                    print(f"  ESS Power:        {live_data.ess_p} kW")
+                if live_data.ess_en is not None:
+                    print(f"  ESS Energy:       {live_data.ess_en} kWh")
+                if live_data.soc is not None:
+                    print(f"  Battery SOC:      {live_data.soc} %")
+                if live_data.backup_time_remaining is not None:
+                    print(f"  Backup Time:      {live_data.backup_time_remaining} min")
+                if live_data.midstate is not None:
+                    print(f"  MIDC State:       {live_data.midstate}")
+                print("=" * 50)
+
+        except asyncio.CancelledError:
+            pass
+        finally:
+            # Clean up
+            remove_listener()
+            await ws.disconnect()
+            _LOGGER.info("Disconnected")
 
 
 if __name__ == "__main__":

--- a/src/pypvs/__init__.py
+++ b/src/pypvs/__init__.py
@@ -11,7 +11,9 @@ from .exceptions import (
 
 # isort: on
 from .models.inverter import PVSInverter
+from .models.livedata import PVSLiveData
 from .pvs import PVS
+from .pvs_websocket import ConnectionState, PVSWebSocket
 
 __all__ = (
     "register_updater",
@@ -22,6 +24,9 @@ __all__ = (
     "PVSFirmwareCheckError",
     "PVSAuthenticationError",
     "PVSInverter",
+    "PVSLiveData",
+    "PVSWebSocket",
+    "ConnectionState",
 )
 
 try:

--- a/src/pypvs/models/livedata.py
+++ b/src/pypvs/models/livedata.py
@@ -1,0 +1,137 @@
+"""Model for PVS live data."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any
+
+# Mapping from varserver path to attribute name
+_VAR_PATH_TO_ATTR: dict[str, str] = {
+    "/sys/livedata/time": "time",
+    "/sys/livedata/pv_p": "pv_p",
+    "/sys/livedata/pv_en": "pv_en",
+    "/sys/livedata/net_p": "net_p",
+    "/sys/livedata/net_en": "net_en",
+    "/sys/livedata/site_load_p": "site_load_p",
+    "/sys/livedata/site_load_en": "site_load_en",
+    "/sys/livedata/ess_en": "ess_en",
+    "/sys/livedata/ess_p": "ess_p",
+    "/sys/livedata/soc": "soc",
+    "/sys/livedata/backupTimeRemaining": "backup_time_remaining",
+    "/sys/livedata/midstate": "midstate",
+}
+
+
+@dataclass(slots=True)
+class PVSLiveData:
+    """Container for PVS live data values.
+
+    Attributes:
+        time: Timestamp of the live data reading
+        pv_p: Solar production power in kW
+        pv_en: Solar production energy in kWh
+        net_p: Net grid power in kW (positive = importing, negative = exporting)
+        net_en: Net grid energy in kWh
+        site_load_p: Site load power in kW
+        site_load_en: Site load energy in kWh
+        ess_en: Battery energy in kWh
+        ess_p: Battery power in kW (positive = discharging, negative = charging)
+        soc: Battery state of charge percentage
+        backup_time_remaining: Estimated backup time remaining in minutes
+        midstate: MIDC transfer switch state
+    """
+
+    time: datetime | None = None
+    pv_p: float | None = None
+    pv_en: float | None = None
+    net_p: float | None = None
+    net_en: float | None = None
+    site_load_p: float | None = None
+    site_load_en: float | None = None
+    ess_en: float | None = None
+    ess_p: float | None = None
+    soc: float | None = None
+    backup_time_remaining: float | None = None
+    midstate: str | None = None
+
+    def get(self, var_name: str) -> Any:
+        """Get value by varserver path.
+
+        Args:
+            var_name: The varserver path (e.g., "/sys/livedata/pv_p")
+
+        Returns:
+            The value for that path, or None if not found
+        """
+        attr = _VAR_PATH_TO_ATTR.get(var_name)
+        if attr:
+            return getattr(self, attr, None)
+        return None
+
+    @classmethod
+    def from_varserver(cls, data: dict[str, Any]) -> PVSLiveData:
+        """Initialize from /sys/livedata/* varserver variables.
+
+        Args:
+            data: Dictionary with varserver paths as keys
+
+        Returns:
+            PVSLiveData instance with parsed values
+        """
+        return cls(
+            time=cls._parse_timestamp(data.get("/sys/livedata/time")),
+            pv_p=cls._parse_numeric(data.get("/sys/livedata/pv_p")),
+            pv_en=cls._parse_numeric(data.get("/sys/livedata/pv_en")),
+            net_p=cls._parse_numeric(data.get("/sys/livedata/net_p")),
+            net_en=cls._parse_numeric(data.get("/sys/livedata/net_en")),
+            site_load_p=cls._parse_numeric(data.get("/sys/livedata/site_load_p")),
+            site_load_en=cls._parse_numeric(data.get("/sys/livedata/site_load_en")),
+            ess_en=cls._parse_numeric(data.get("/sys/livedata/ess_en")),
+            ess_p=cls._parse_numeric(data.get("/sys/livedata/ess_p")),
+            soc=cls._parse_numeric(data.get("/sys/livedata/soc")),
+            backup_time_remaining=cls._parse_numeric(
+                data.get("/sys/livedata/backupTimeRemaining")
+            ),
+            midstate=data.get("/sys/livedata/midstate"),
+        )
+
+    @staticmethod
+    def _parse_numeric(value: Any) -> float | None:
+        """Parse a numeric value from varserver response."""
+        if value is None:
+            return None
+        if isinstance(value, (int, float)):
+            return float(value)
+        if isinstance(value, str):
+            if value.lower() in ("nan", "null", ""):
+                return None
+            try:
+                return float(value)
+            except (ValueError, TypeError):
+                return None
+        return None
+
+    @staticmethod
+    def _parse_timestamp(value: Any) -> datetime | None:
+        """Parse a timestamp value from varserver response.
+
+        Handles both Unix seconds and milliseconds formats.
+        """
+        if value is None:
+            return None
+        try:
+            timestamp = int(value) if isinstance(value, str) else int(value)
+            current_time = datetime.now(timezone.utc).timestamp()
+
+            # Detect milliseconds vs seconds
+            if timestamp > current_time + (365 * 24 * 3600):
+                timestamp = timestamp / 1000
+
+            # Validate
+            if timestamp < 0 or timestamp > current_time + (365 * 24 * 3600):
+                return None
+
+            return datetime.fromtimestamp(timestamp, tz=timezone.utc)
+        except (ValueError, TypeError, OSError):
+            return None

--- a/src/pypvs/models/livedata.py
+++ b/src/pypvs/models/livedata.py
@@ -6,20 +6,32 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any
 
-# Mapping from varserver path to attribute name
+# Canonical field definitions for livedata.
+# Each tuple: (ws_field_name, var_path, attr_name, value_type)
+LIVEDATA_FIELD_DEFINITIONS: tuple[tuple[str, str, str, str], ...] = (
+    ("time", "/sys/livedata/time", "time", "timestamp"),
+    ("pv_p", "/sys/livedata/pv_p", "pv_p", "numeric"),
+    ("pv_en", "/sys/livedata/pv_en", "pv_en", "numeric"),
+    ("net_p", "/sys/livedata/net_p", "net_p", "numeric"),
+    ("net_en", "/sys/livedata/net_en", "net_en", "numeric"),
+    ("site_load_p", "/sys/livedata/site_load_p", "site_load_p", "numeric"),
+    ("site_load_en", "/sys/livedata/site_load_en", "site_load_en", "numeric"),
+    ("ess_en", "/sys/livedata/ess_en", "ess_en", "numeric"),
+    ("ess_p", "/sys/livedata/ess_p", "ess_p", "numeric"),
+    ("soc", "/sys/livedata/soc", "soc", "numeric"),
+    (
+        "backupTimeRemaining",
+        "/sys/livedata/backupTimeRemaining",
+        "backup_time_remaining",
+        "numeric",
+    ),
+    ("midstate", "/sys/livedata/midstate", "midstate", "string"),
+)
+
+# Mapping from varserver path to attribute name (derived from field definitions)
 _VAR_PATH_TO_ATTR: dict[str, str] = {
-    "/sys/livedata/time": "time",
-    "/sys/livedata/pv_p": "pv_p",
-    "/sys/livedata/pv_en": "pv_en",
-    "/sys/livedata/net_p": "net_p",
-    "/sys/livedata/net_en": "net_en",
-    "/sys/livedata/site_load_p": "site_load_p",
-    "/sys/livedata/site_load_en": "site_load_en",
-    "/sys/livedata/ess_en": "ess_en",
-    "/sys/livedata/ess_p": "ess_p",
-    "/sys/livedata/soc": "soc",
-    "/sys/livedata/backupTimeRemaining": "backup_time_remaining",
-    "/sys/livedata/midstate": "midstate",
+    var_path: attr_name
+    for _, var_path, attr_name, _ in LIVEDATA_FIELD_DEFINITIONS
 }
 
 

--- a/src/pypvs/pvs.py
+++ b/src/pypvs/pvs.py
@@ -22,6 +22,7 @@ from .models.pvs import PVSData
 from .pvs_fcgi import PVSFCGIClient, PVSFCGIClientLoginError, PVSFCGIClientPostError
 
 # isort: on
+from .pvs_websocket import PVSWebSocket
 from .updaters.base import PVSUpdater
 from .updaters.ess import PVSESSUpdater
 from .updaters.gateway import PVSGatewayUpdater
@@ -219,3 +220,22 @@ class PVS:
         """Return the supported features."""
         assert self._supported_features is not None, "Call setup() first"  # nosec
         return self._supported_features
+
+    async def enable_telemetry_websocket(self) -> None:
+        """Enable the telemetry websocket on the PVS."""
+        await self.getVarserver("/vars", params={"set": "/sys/telemetryws/enable=1"})
+
+    def get_websocket(self, port: int = 9002) -> PVSWebSocket:
+        """Create a PVSWebSocket pre-configured to enable telemetry on connect.
+
+        Args:
+            port: WebSocket port (default 9002)
+
+        Returns:
+            PVSWebSocket instance with enable callback wired up
+        """
+        return PVSWebSocket(
+            host=self._host,
+            port=port,
+            enable_callback=self.enable_telemetry_websocket,
+        )

--- a/src/pypvs/pvs_websocket.py
+++ b/src/pypvs/pvs_websocket.py
@@ -1,0 +1,387 @@
+"""WebSocket client for PVS live data."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import random
+import time
+from collections.abc import Callable
+from enum import Enum
+from typing import Any
+
+import aiohttp
+
+from .models.livedata import PVSLiveData
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class ConnectionState(Enum):
+    """WebSocket connection state."""
+
+    DISCONNECTED = "disconnected"
+    CONNECTING = "connecting"
+    CONNECTED = "connected"
+
+
+# Mapping from WebSocket field name to (var_path, attr_name, value_type)
+_FIELD_DEFINITIONS: tuple[tuple[str, str, str, str], ...] = (
+    ("time", "/sys/livedata/time", "time", "timestamp"),
+    ("pv_p", "/sys/livedata/pv_p", "pv_p", "numeric"),
+    ("pv_en", "/sys/livedata/pv_en", "pv_en", "numeric"),
+    ("net_p", "/sys/livedata/net_p", "net_p", "numeric"),
+    ("net_en", "/sys/livedata/net_en", "net_en", "numeric"),
+    ("site_load_p", "/sys/livedata/site_load_p", "site_load_p", "numeric"),
+    ("site_load_en", "/sys/livedata/site_load_en", "site_load_en", "numeric"),
+    ("ess_en", "/sys/livedata/ess_en", "ess_en", "numeric"),
+    ("ess_p", "/sys/livedata/ess_p", "ess_p", "numeric"),
+    ("soc", "/sys/livedata/soc", "soc", "numeric"),
+    (
+        "backupTimeRemaining",
+        "/sys/livedata/backupTimeRemaining",
+        "backup_time_remaining",
+        "numeric",
+    ),
+    ("midstate", "/sys/livedata/midstate", "midstate", "string"),
+)
+
+# Pre-built lookup table for websocket message processing
+_WS_FIELD_MAP: dict[str, tuple[str, str, str]] = {
+    ws_field: (var_path, attr_name, value_type)
+    for ws_field, var_path, attr_name, value_type in _FIELD_DEFINITIONS
+}
+
+
+# Type aliases for callbacks
+LiveDataCallback = Callable[[set[str]], None]
+ConnectionStateCallback = Callable[[ConnectionState], None]
+
+
+class PVSWebSocket:
+    """WebSocket client for PVS live data with auto-reconnect."""
+
+    def __init__(self, host: str, port: int = 9002) -> None:
+        """Initialize the WebSocket client.
+
+        Args:
+            host: PVS hostname or IP address
+            port: WebSocket port (default 9002)
+        """
+        self._host = host
+        self._port = port
+        self._callbacks: list[LiveDataCallback] = []
+        self._state_callbacks: list[ConnectionStateCallback] = []
+        self._task: asyncio.Task | None = None
+        self._live_data: PVSLiveData | None = None
+        self._timestamp_format: str | None = None
+        self._stopping = False
+        self._state = ConnectionState.DISCONNECTED
+
+    @property
+    def live_data(self) -> PVSLiveData | None:
+        """Return current live data."""
+        return self._live_data
+
+    @property
+    def is_connected(self) -> bool:
+        """Return True if websocket is connected and receiving data."""
+        return self._state == ConnectionState.CONNECTED
+
+    @property
+    def state(self) -> ConnectionState:
+        """Return current connection state."""
+        return self._state
+
+    def _set_state(self, state: ConnectionState) -> None:
+        """Update connection state and notify listeners."""
+        if self._state != state:
+            self._state = state
+            for callback in list(self._state_callbacks):
+                try:
+                    callback(state)
+                except Exception as e:
+                    _LOGGER.error("Error in state callback: %s", e)
+
+    def add_listener(self, callback: LiveDataCallback) -> Callable[[], None]:
+        """Add a listener for live data updates.
+
+        Args:
+            callback: Function called with set of changed variable names
+
+        Returns:
+            Function to remove the listener
+        """
+        self._callbacks.append(callback)
+
+        def remove() -> None:
+            if callback in self._callbacks:
+                self._callbacks.remove(callback)
+
+        return remove
+
+    def add_state_listener(
+        self, callback: ConnectionStateCallback
+    ) -> Callable[[], None]:
+        """Add a listener for connection state changes.
+
+        Args:
+            callback: Function called with new ConnectionState
+
+        Returns:
+            Function to remove the listener
+        """
+        self._state_callbacks.append(callback)
+
+        def remove() -> None:
+            if callback in self._state_callbacks:
+                self._state_callbacks.remove(callback)
+
+        return remove
+
+    async def connect(self) -> None:
+        """Start the WebSocket connection with auto-reconnect."""
+        if self._task and not self._task.done():
+            _LOGGER.debug("WebSocket already running")
+            return
+
+        self._stopping = False
+        self._task = asyncio.create_task(self._run_websocket())
+
+    async def disconnect(self) -> None:
+        """Stop the WebSocket connection."""
+        self._stopping = True
+
+        if self._task and not self._task.done():
+            self._task.cancel()
+            try:
+                await asyncio.wait_for(self._task, timeout=2.0)
+            except (asyncio.CancelledError, asyncio.TimeoutError):
+                pass
+
+        self._task = None
+        self._live_data = None
+        self._set_state(ConnectionState.DISCONNECTED)
+
+    async def _run_websocket(self) -> None:
+        """Run WebSocket connection loop with auto-reconnect."""
+        websocket_url = f"ws://{self._host}:{self._port}"
+        _LOGGER.info("Starting WebSocket connection to %s", websocket_url)
+
+        reconnect_count = 0
+        fast_retry_limit = 3
+        fast_retry_delay = 2
+        backoff_delay = 5.0
+        max_backoff = 300
+        stale_timeout = 90
+
+        # Reuse session across reconnects
+        session: aiohttp.ClientSession | None = None
+
+        try:
+            while not self._stopping:
+                heartbeat_task = None
+                last_message_time: float = 0
+
+                try:
+                    # Create session if needed
+                    if session is None or session.closed:
+                        session = aiohttp.ClientSession(
+                            timeout=aiohttp.ClientTimeout(total=30, connect=10),
+                            connector=aiohttp.TCPConnector(
+                                limit=1,
+                                limit_per_host=1,
+                                ttl_dns_cache=300,
+                                use_dns_cache=True,
+                                enable_cleanup_closed=True,
+                            ),
+                        )
+
+                    self._set_state(ConnectionState.CONNECTING)
+                    _LOGGER.info(
+                        "Attempting WebSocket connection to %s (attempt %d)",
+                        websocket_url,
+                        reconnect_count + 1,
+                    )
+
+                    async with session.ws_connect(
+                        websocket_url,
+                        heartbeat=30,
+                        compress=0,
+                    ) as ws:
+                        reconnect_count = 0
+                        backoff_delay = 5.0
+                        _LOGGER.info("WebSocket connected to %s", websocket_url)
+
+                        # Initialize live data
+                        self._live_data = PVSLiveData()
+                        self._timestamp_format = None
+                        last_message_time = time.monotonic()
+                        self._set_state(ConnectionState.CONNECTED)
+
+                        # Start heartbeat monitor
+                        async def monitor_heartbeat() -> None:
+                            nonlocal last_message_time
+                            while True:
+                                await asyncio.sleep(30)
+                                elapsed = time.monotonic() - last_message_time
+                                if elapsed > stale_timeout:
+                                    _LOGGER.warning(
+                                        "WebSocket stale (no messages for %.0fs), closing",
+                                        elapsed,
+                                    )
+                                    await ws.close()
+                                    break
+
+                        heartbeat_task = asyncio.create_task(monitor_heartbeat())
+
+                        async for msg in ws:
+                            last_message_time = time.monotonic()
+
+                            if msg.type == aiohttp.WSMsgType.TEXT:
+                                try:
+                                    data = json.loads(msg.data)
+                                    self._process_message(data)
+                                except json.JSONDecodeError:
+                                    _LOGGER.debug("Invalid JSON in WebSocket message")
+                            elif msg.type == aiohttp.WSMsgType.ERROR:
+                                _LOGGER.warning("WebSocket error: %s", ws.exception())
+                                break
+                            elif msg.type in (
+                                aiohttp.WSMsgType.CLOSE,
+                                aiohttp.WSMsgType.CLOSED,
+                            ):
+                                _LOGGER.info("WebSocket closed by server")
+                                break
+
+                except asyncio.CancelledError:
+                    _LOGGER.debug("WebSocket cancelled")
+                    raise
+                except Exception as e:
+                    reconnect_count += 1
+                    _LOGGER.error(
+                        "WebSocket connection failed (attempt %d): %s",
+                        reconnect_count,
+                        e,
+                    )
+                finally:
+                    if heartbeat_task and not heartbeat_task.done():
+                        heartbeat_task.cancel()
+                        try:
+                            await heartbeat_task
+                        except asyncio.CancelledError:
+                            pass
+
+                    self._live_data = None
+                    self._set_state(ConnectionState.DISCONNECTED)
+
+                if self._stopping:
+                    break
+
+                # Calculate retry delay
+                if reconnect_count <= fast_retry_limit:
+                    actual_delay = float(fast_retry_delay)
+                    _LOGGER.info(
+                        "Fast retry in %ds (attempt %d/%d)",
+                        actual_delay,
+                        reconnect_count,
+                        fast_retry_limit,
+                    )
+                else:
+                    delay = min(
+                        backoff_delay
+                        * (2 ** min(reconnect_count - fast_retry_limit - 1, 5)),
+                        max_backoff,
+                    )
+                    jitter = random.uniform(0.8, 1.2)
+                    actual_delay = delay * jitter
+                    _LOGGER.info(
+                        "Reconnecting in %.1fs (exponential backoff)", actual_delay
+                    )
+                    backoff_delay = min(backoff_delay * 1.5, max_backoff)
+
+                try:
+                    await asyncio.sleep(actual_delay)
+                except asyncio.CancelledError:
+                    _LOGGER.debug("WebSocket reconnection cancelled")
+                    raise
+
+        finally:
+            # Clean up session on exit
+            if session and not session.closed:
+                await session.close()
+
+    def _process_message(self, data: dict) -> None:
+        """Process incoming WebSocket message."""
+        if data.get("notification") != "power" or "params" not in data:
+            return
+
+        if self._live_data is None:
+            return
+
+        params = data["params"]
+        changed_vars: set[str] = set()
+
+        for ws_field, (var_path, attr_name, value_type) in _WS_FIELD_MAP.items():
+            if ws_field not in params:
+                continue
+
+            new_value = self._convert_value(params[ws_field], value_type)
+            old_value = getattr(self._live_data, attr_name, None)
+
+            if old_value != new_value:
+                setattr(self._live_data, attr_name, new_value)
+                changed_vars.add(var_path)
+
+        if changed_vars:
+            # Iterate over a copy in case callbacks modify the list
+            for callback in list(self._callbacks):
+                try:
+                    callback(changed_vars)
+                except Exception as e:
+                    _LOGGER.error("Error in live data callback: %s", e)
+
+    def _convert_value(self, raw_value: Any, value_type: str) -> Any:
+        """Convert raw WebSocket value to appropriate type."""
+        if value_type == "string":
+            return str(raw_value) if raw_value is not None else None
+
+        if value_type == "numeric":
+            return PVSLiveData._parse_numeric(raw_value)
+
+        if value_type == "timestamp":
+            # Use cached format detection for websocket stream
+            return self._convert_timestamp(raw_value)
+
+        return None
+
+    def _convert_timestamp(self, raw_value: Any) -> Any:
+        """Convert timestamp with format caching for websocket stream."""
+        if raw_value is None:
+            return None
+        try:
+            import datetime
+
+            timestamp = int(raw_value) if isinstance(raw_value, str) else int(raw_value)
+            current_time = datetime.datetime.now(datetime.timezone.utc).timestamp()
+
+            # Detect and cache timestamp format
+            if self._timestamp_format == "milliseconds":
+                timestamp = timestamp / 1000
+            elif self._timestamp_format == "seconds":
+                pass
+            else:
+                if timestamp > current_time + (365 * 24 * 3600):
+                    self._timestamp_format = "milliseconds"
+                    timestamp = timestamp / 1000
+                else:
+                    self._timestamp_format = "seconds"
+
+            # Validate
+            if timestamp < 0 or timestamp > current_time + (365 * 24 * 3600):
+                return None
+
+            return datetime.datetime.fromtimestamp(timestamp, tz=datetime.timezone.utc)
+        except (ValueError, TypeError, OSError):
+            return None

--- a/src/pypvs/pvs_websocket.py
+++ b/src/pypvs/pvs_websocket.py
@@ -13,7 +13,7 @@ from typing import Any
 
 import aiohttp
 
-from .models.livedata import PVSLiveData
+from .models.livedata import LIVEDATA_FIELD_DEFINITIONS, PVSLiveData
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -26,31 +26,11 @@ class ConnectionState(Enum):
     CONNECTED = "connected"
 
 
-# Mapping from WebSocket field name to (var_path, attr_name, value_type)
-_FIELD_DEFINITIONS: tuple[tuple[str, str, str, str], ...] = (
-    ("time", "/sys/livedata/time", "time", "timestamp"),
-    ("pv_p", "/sys/livedata/pv_p", "pv_p", "numeric"),
-    ("pv_en", "/sys/livedata/pv_en", "pv_en", "numeric"),
-    ("net_p", "/sys/livedata/net_p", "net_p", "numeric"),
-    ("net_en", "/sys/livedata/net_en", "net_en", "numeric"),
-    ("site_load_p", "/sys/livedata/site_load_p", "site_load_p", "numeric"),
-    ("site_load_en", "/sys/livedata/site_load_en", "site_load_en", "numeric"),
-    ("ess_en", "/sys/livedata/ess_en", "ess_en", "numeric"),
-    ("ess_p", "/sys/livedata/ess_p", "ess_p", "numeric"),
-    ("soc", "/sys/livedata/soc", "soc", "numeric"),
-    (
-        "backupTimeRemaining",
-        "/sys/livedata/backupTimeRemaining",
-        "backup_time_remaining",
-        "numeric",
-    ),
-    ("midstate", "/sys/livedata/midstate", "midstate", "string"),
-)
-
 # Pre-built lookup table for websocket message processing
+# Maps ws_field_name -> (var_path, attr_name, value_type)
 _WS_FIELD_MAP: dict[str, tuple[str, str, str]] = {
     ws_field: (var_path, attr_name, value_type)
-    for ws_field, var_path, attr_name, value_type in _FIELD_DEFINITIONS
+    for ws_field, var_path, attr_name, value_type in LIVEDATA_FIELD_DEFINITIONS
 }
 
 

--- a/src/pypvs/pvs_websocket.py
+++ b/src/pypvs/pvs_websocket.py
@@ -62,15 +62,24 @@ ConnectionStateCallback = Callable[[ConnectionState], None]
 class PVSWebSocket:
     """WebSocket client for PVS live data with auto-reconnect."""
 
-    def __init__(self, host: str, port: int = 9002) -> None:
+    def __init__(
+        self,
+        host: str,
+        port: int = 9002,
+        enable_callback: Callable[[], Any] | None = None,
+    ) -> None:
         """Initialize the WebSocket client.
 
         Args:
             host: PVS hostname or IP address
             port: WebSocket port (default 9002)
+            enable_callback: Optional async callable invoked before each
+                connection attempt to ensure the telemetry websocket is
+                enabled on the PVS.
         """
         self._host = host
         self._port = port
+        self._enable_callback = enable_callback
         self._callbacks: list[LiveDataCallback] = []
         self._state_callbacks: list[ConnectionStateCallback] = []
         self._task: asyncio.Task | None = None
@@ -199,6 +208,16 @@ class PVSWebSocket:
                         )
 
                     self._set_state(ConnectionState.CONNECTING)
+
+                    # Ensure telemetry websocket is enabled on the PVS
+                    if self._enable_callback is not None:
+                        try:
+                            await self._enable_callback()
+                        except Exception as e:
+                            _LOGGER.warning(
+                                "Failed to enable telemetry websocket: %s", e
+                            )
+
                     _LOGGER.info(
                         "Attempting WebSocket connection to %s (attempt %d)",
                         websocket_url,


### PR DESCRIPTION
This PR adds support for real-time live data reporting via the WebSocket on the PVS. This is required to support adding live data to the home assistant integration (PR: https://github.com/SunStrong-Management/pvs-hass/pull/25).

High level features:
- Connects to PVS WebSocket on port 9002 for real-time power/energy data
- Auto-reconnect with fast retry (3 attempts at 2s intervals) then exponential backoff up to 5 minutes
- Stale connection detection (closes if no messages for 90 seconds)
- ConnectionState enum (DISCONNECTED, CONNECTING, CONNECTED) with state change callbacks
- Only reports values that actually changed (compares old vs new values)
- Example script included to validate functionality