### PR TITLE
Improve handling of connection errors or unavailable device data

### DIFF
--- a/src/pypvs/pvs.py
+++ b/src/pypvs/pvs.py
@@ -80,12 +80,12 @@ class PVS:
             )
             _LOGGER.debug(f"Received response: {response_data}")
             return response_data
-        except PVSFCGIClientPostError:
-            raise PVSCommunicationError("POST request failed")
-        except PVSFCGIClientLoginError:
-            raise PVSAuthenticationError("Login to the PVS failed")
-        except Exception:
-            raise PVSError("General error")
+        except PVSFCGIClientLoginError as err:
+            raise PVSAuthenticationError(f"Login to the PVS failed: {err}") from err
+        except PVSFCGIClientPostError as err:
+            raise PVSCommunicationError(f"POST request failed: {err}") from err
+        except Exception as err:
+            raise PVSError(f"Unexpected error communicating with PVS: {err}") from err
 
     async def getVarserverVar(self, varname):
         response_data = await self.getVarserver("/vars", params={"name": varname})

--- a/src/pypvs/pvs_fcgi.py
+++ b/src/pypvs/pvs_fcgi.py
@@ -84,19 +84,33 @@ class PVSFCGIClient:
         async with self.session.post(
             url, cookies=self.cookies, data=payload_str, ssl=False
         ) as response:
-            await response.text()
-            # FIXME: The server returns 500 or 200 with empty response when
-            # the session is invalid
+            response_body = await response.text()
+
             if response.status == 200:
                 _LOGGER.debug("POST request successful!")
-                return await response.json()
-            elif response.status in [400, 401, 500]:
+                import json
+                return json.loads(response_body)
+            elif response.status in [401, 500]:
+                # Session expired or invalid — caller should re-authenticate
+                _LOGGER.debug(
+                    "PVS returned HTTP %s for %s — body: %s",
+                    response.status,
+                    url,
+                    response_body[:500],
+                )
                 raise PVSFCGIClientLoginError(
-                    "Unauthorized access (missing cookie). Retry login!"
+                    f"HTTP {response.status}: {response_body[:200]}"
                 )
             else:
+                # 400 or other status — not an auth issue, don't retry login
+                _LOGGER.debug(
+                    "PVS returned HTTP %s for %s — body: %s",
+                    response.status,
+                    url,
+                    response_body[:500],
+                )
                 raise PVSFCGIClientPostError(
-                    f"POST request failed with status code: {response.status}"
+                    f"HTTP {response.status}: {response_body[:200]}"
                 )
 
     async def execute_post_request(self, endpoint, params=None):

--- a/src/pypvs/updaters/base.py
+++ b/src/pypvs/updaters/base.py
@@ -20,6 +20,7 @@ class PVSUpdater:
         self._request_vars = request_vars
         self._supported_features = SupportedFeatures(0)
         self._common_properties = common_properties
+        self._data_unavailable = False
 
     @abstractmethod
     async def probe(

--- a/src/pypvs/updaters/ess.py
+++ b/src/pypvs/updaters/ess.py
@@ -30,8 +30,16 @@ class PVSESSUpdater(PVSUpdater):
         try:
             ess_dict: list[dict[str, Any]] = await self._request_vars(VARS_MATCH_ESS)
         except Exception as e:
-            _LOGGER.error("Failed to request ESS vars: %s", e)
+            if not self._data_unavailable:
+                _LOGGER.warning("ESS data unavailable: %s", e)
+                self._data_unavailable = True
+            else:
+                _LOGGER.debug("ESS data still unavailable: %s", e)
             return
+
+        if self._data_unavailable:
+            _LOGGER.info("ESS data recovered")
+            self._data_unavailable = False
 
         try:
             # construct a list of ESS from the provided dictionary, drop all parent path

--- a/src/pypvs/updaters/meter.py
+++ b/src/pypvs/updaters/meter.py
@@ -34,8 +34,16 @@ class PVSProductionMetersUpdater(PVSUpdater):
                 VARS_MATCH_METERS
             )
         except Exception as e:
-            _LOGGER.error("Failed to request meter vars: %s", e)
+            if not self._data_unavailable:
+                _LOGGER.warning("Meter data unavailable: %s", e)
+                self._data_unavailable = True
+            else:
+                _LOGGER.debug("Meter data still unavailable: %s", e)
             return
+
+        if self._data_unavailable:
+            _LOGGER.info("Meter data recovered")
+            self._data_unavailable = False
 
         try:
             # construct a list of meters from the provided dictionary,

--- a/src/pypvs/updaters/production_inverters.py
+++ b/src/pypvs/updaters/production_inverters.py
@@ -34,8 +34,16 @@ class PVSProductionInvertersUpdater(PVSUpdater):
                 VARS_MATCH_INVERTERS
             )
         except Exception as e:
-            _LOGGER.error("Failed to request inverter vars: %s", e)
+            if not self._data_unavailable:
+                _LOGGER.warning("Inverter data unavailable: %s", e)
+                self._data_unavailable = True
+            else:
+                _LOGGER.debug("Inverter data still unavailable: %s", e)
             return
+
+        if self._data_unavailable:
+            _LOGGER.info("Inverter data recovered")
+            self._data_unavailable = False
 
         try:
             # construct a list of inverters from the provided dictionary,

--- a/src/pypvs/updaters/transfer_switch.py
+++ b/src/pypvs/updaters/transfer_switch.py
@@ -36,8 +36,16 @@ class PVSTransferSwitchUpdater(PVSUpdater):
                 VARS_MATCH_TRANSFER_SWITCH
             )
         except Exception as e:
-            _LOGGER.error("Failed to request transfer switch vars: %s", e)
+            if not self._data_unavailable:
+                _LOGGER.warning("Transfer switch data unavailable: %s", e)
+                self._data_unavailable = True
+            else:
+                _LOGGER.debug("Transfer switch data still unavailable: %s", e)
             return
+
+        if self._data_unavailable:
+            _LOGGER.info("Transfer switch data recovered")
+            self._data_unavailable = False
 
         try:
             # construct a list of transfer switches from the provided dictionary,


### PR DESCRIPTION
When the PVS gateway reboots (typically overnight), all varserver requests fail until it comes back. Previously this produced a wall of ERROR-level log lines every poll cycle for every device type. Most devices come back online as the PVS boots, except inverters which won't return until the sun rises and they come online. For me, that resulted in the integration spamming the Home Assistant logs with 1000+ entries saying `Failed to request inverter vars: Login to the PVS failed`, which was both expected (inverters are offline) and inaccurate (login was not failing).

This change improves classification of these errors as previously 400, 401, and 500 responses were classified as Login Errors, causing unneccessary re-auth attempts. Now only 401 and 500 will raise a login error, while 400 and others raise Post errors. Response bodies are bubbled up in the error message for easier troubleshooting as well. 

The overall amount of error logging is also reduced as the updater will log a single message at WARNING when data first becomes unavailable, then log subsequent failures at DEBUG. When data returns, it will log a single message at INFO. 