### PR TITLE
Resolve login failures at startup and remove cookie_jar.clear()

### DIFF
--- a/src/pypvs/pvs_fcgi.py
+++ b/src/pypvs/pvs_fcgi.py
@@ -76,10 +76,6 @@ class PVSFCGIClient:
             _LOGGER.info(f"Login successful! with cookies: {self.cookies}")
 
     async def _post_internal(self, url, payload_str):
-        # Cookies seem to be added implicitly, so need to clear them for a new PVS
-        # https://docs.aiohttp.org/en/stable/client_advanced.html#cookie-jar
-        self.session.cookie_jar.clear()
-
         # TODO: Ignore certificate errors for now
         async with self.session.post(
             url, cookies=self.cookies, data=payload_str, ssl=False
@@ -126,11 +122,15 @@ class PVSFCGIClient:
             f"and cookies: {self.cookies}"
         )
 
-        # First try our luck if the session is still valid
+        # Proactively login if we don't have a session yet
+        if self.cookies is None and self.auth_user:
+            await self.login_basic()
+
+        # Try the request — may fail if session expired
         try:
             return await self._post_internal(url, payload_str)
         except PVSFCGIClientLoginError:
-            _LOGGER.warning("Unauthorized access. Retrying login...")
+            _LOGGER.debug("Session expired. Re-authenticating...")
 
         # Retry login to refresh the session cookies
         await self.login_basic()

--- a/src/pypvs/pvs_fcgi.py
+++ b/src/pypvs/pvs_fcgi.py
@@ -123,7 +123,7 @@ class PVSFCGIClient:
         )
 
         # Proactively login if we don't have a session yet
-        if self.cookies is None and self.auth_user:
+        if self.cookies is None and self.auth_user and self.auth_password:
             await self.login_basic()
 
         # Try the request — may fail if session expired


### PR DESCRIPTION
This one has been on my mind for a while, finally got around to looking at it. 

The changes here will ensure a proactive login is performed if there are no cookies present and we have auth credentials. This avoids the guaranteed to fail first attempt on Home Assistant startup and elmiinates the `Unauthorized access. Retrying login...` errors in the HA logs that were present on every startup.

Also, the cookie_jar.clear() call in post_internal() has been removed. It was unneccessary and especially problematic with Home Assistant as the aiohttp session (and cookie jar) is managed centrally. This call could potentially break other integrations using the cookie jar. This resolves https://github.com/SunStrong-Management/pypvs/issues/44