### PR TITLE
Remove erroneous login_basic() precondition

### DIFF
--- a/src/pypvs/pvs_fcgi.py
+++ b/src/pypvs/pvs_fcgi.py
@@ -42,8 +42,6 @@ class PVSFCGIClient:
     async def login_basic(self):
         if not self.auth_user:
             raise PVSFCGIClientLoginError("Auth user must be set before logging in.")
-        if not self.pvs_details or not self.pvs_details.get("serial"):
-            raise PVSFCGIClientLoginError("PVS details must be set before logging in.")
 
         # The PVS uses basic authentication with the username and password
         auth_token = base64.b64encode(


### PR DESCRIPTION
A latent login issue appeared after I installed pypvs from the main branch with the latest PR's in my HA instance. For some reason this did not present during my initial testing of https://github.com/SunStrong-Management/pypvs/pull/48, however I began to see an issue with the integration persistently having login failures:

```
2026-04-27 15:40:37.390 WARNING (MainThread) [homeassistant.config_entries] Config entry 'PVS' for sunstrong_pvs integration could not authenticate: Login to the PVS failed: PVS details must be set before logging in.
```

I found there is a guard in the login_basic() method in pvs_fcgi.py requiring pvs_details to be set, but that is never actually used in the method. Removing this guard resolved the login issue.